### PR TITLE
Adds option to keep association identifiers

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -29,7 +29,7 @@ Controller.prototype.initialize = function(args) {
     });
 
     _.forEach(this.model.associations, function(association) {
-      if (_.contains(includeModels, association.target))
+      if (_.contains(includeModels, association.target) && !args.keepIncludeIdentifier)
         includeAttributes.push(association.identifier);
     });
     this.includeAttributes = includeAttributes;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -13,7 +13,8 @@ var Resource = function(options) {
     sort: {
       param: 'sort'
     },
-    reloadInstances: true
+    reloadInstances: true,
+    keepIncludeIdentifier: false
   });
 
   this.app = options.app;
@@ -43,7 +44,8 @@ var Resource = function(options) {
       app: this.app,
       model: this.model,
       include: this.include,
-      resource: this
+      resource: this,
+      keepIncludeIdentifier: options.keepIncludeIdentifier
     });
 
   }.bind(this));

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,8 @@ var epilogue = {
       updateMethod: this.updateMethod,
       search: args.search,
       sort: args.sort,
-      reloadInstances: args.reloadInstances
+      reloadInstances: args.reloadInstances,
+      keepIncludeIdentifier: args.keepIncludeIdentifier
     });
 
     return resource;


### PR DESCRIPTION
Ex:

```
rest.resource({
     model: test.models.Person,
     include: [
          { model: test.models.Address, as: 'addy' },
          { model: test.models.Hobby, as: 'hobbies' }
     ],
     endpoints: ['/person', '/person/:id'],
     keepIncludeIdentifier: true
});
```
